### PR TITLE
Do not change global logging level

### DIFF
--- a/src/pyace/__init__.py
+++ b/src/pyace/__init__.py
@@ -4,7 +4,7 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                     # datefmt='%Y-%m-%d %H:%M:%S.%f'
                     )
-logging.getLogger().setLevel(logging.INFO)
+logging.getLogger(__name__).setLevel(logging.INFO)
 
 from pyace.asecalc import PyACECalculator, PyACEEnsembleCalculator
 


### PR DESCRIPTION
Because of 

https://github.com/ICAMS/python-ace/blob/6d3e5b8af52705408affd06a3dc6739da36e7078/src/pyace/__init__.py#L7

just importing `pyace` changes the global logging level.  This also seems to affect other loggers that are not the root logger.  It's a bit annoying for us in pyiron because of this.  

I think this should fix it.