### PR TITLE
 minor change to avoid warning from ase

### DIFF
--- a/src/pyace/asecalc.py
+++ b/src/pyace/asecalc.py
@@ -158,7 +158,7 @@ PyACE ASE calculator
             'energies': self.energies.astype(np.float64),
             'gamma': np.array(self.ace.gamma_grade, dtype=np.float64)
         }
-        if self.atoms.number_of_lattice_vectors == 3:
+        if self.atoms.cell.rank == 3:
             self.volume = atoms.get_volume()
             self.virial = np.array(self.ace.virial)  # order is: xx, yy, zz, xy, xz, yz
             # swap order of the virials to fullfill ASE Voigt stresses order:  (xx, yy, zz, yz, xz, xy)


### PR DESCRIPTION
on my system (fresh install, ase 3.22.1 )  the relevant part of the traceback:

```
    File "/scratch/AnacondaEnvironments/ml_datasets/lib/python3.9/site-packages/ase/atoms.py", line 731, in get_potential_energy
      energy = self._calc.get_potential_energy(self)
    File "/scratch/AnacondaEnvironments/ml_datasets/lib/python3.9/site-packages/ase/calculators/calculator.py", line 709, in get_potential_energy
      energy = self.get_property('energy', atoms)
    File "/scratch/AnacondaEnvironments/ml_datasets/lib/python3.9/site-packages/ase/calculators/calculator.py", line 737, in get_property
      self.calculate(atoms, [name], system_changes)
    File "/scratch/AnacondaEnvironments/ml_datasets/lib/python3.9/site-packages/pyace/asecalc.py", line 161, in calculate
      if self.atoms.number_of_lattice_vectors == 3:
    File "/scratch/AnacondaEnvironments/ml_datasets/lib/python3.9/site-packages/ase/utils/__init__.py", line 62, in deprecated_function
      warnings.warn(warning)
  FutureWarning: Please use atoms.cell.rank instead
```

which is solved with this modification