### PR TITLE
Modify `-DCMAKE_INSTALL_RPATH` for MacOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,10 @@ class CMakeBuild(build_ext):
 
         # Pile all .so in one place and use $ORIGIN as RPATH
         cmake_args += ["-DCMAKE_BUILD_WITH_INSTALL_RPATH=TRUE"]
-        cmake_args += ["-DCMAKE_INSTALL_RPATH={}".format("$ORIGIN")]
+        if platform.system() == "Darwin":  # MacOS
+            cmake_args += ["-DCMAKE_INSTALL_RPATH={}".format("@loader_path")]
+        else:
+            cmake_args += ["-DCMAKE_INSTALL_RPATH={}".format("$ORIGIN")]
         cmake_args += ["-DBUILD_SHARED_LIBS=ON"]
         cmake_args += ["-DYAML_BUILD_SHARED_LIBS=ON"]
 


### PR DESCRIPTION
Thank you so much developers for sharing the code, which helps me quite a lot for jumping into ML-potential researches!

# Short description

This modification allows us to use `pacemaker` also in MacOS.

# Long description

When I installed `pyace` in MacOS and tried to use `pacemaker`, I got the following error message;
```console
% pacemaker -t
Traceback (most recent call last):
  File "/Users/ikeda/miniconda3/envs/myenv/bin/pacemaker", line 26, in <module>
    from pyace.generalfit import GeneralACEFit
  File "/Users/ikeda/miniconda3/envs/myenv/lib/python3.10/site-packages/pyace/__init__.py", line 9, in <module>
    from pyace.asecalc import PyACECalculator, PyACEEnsembleCalculator
  File "/Users/ikeda/miniconda3/envs/myenv/lib/python3.10/site-packages/pyace/asecalc.py", line 7, in <module>
    from pyace.basis import ACEBBasisSet, ACECTildeBasisSet, BBasisConfiguration
ImportError: dlopen(/Users/ikeda/miniconda3/envs/myenv/lib/python3.10/site-packages/pyace/basis.cpython-310-darwin.so, 0x0002): Library not loaded: @rpath/libyaml-cpp-pace.0.6.dylib
  Referenced from: <525B2942-D3A8-351C-8B10-03BD3B9A7E08> /Users/ikeda/miniconda3/envs/myenv/lib/python3.10/site-packages/pyace/basis.cpython-310-darwin.so
  Reason: tried: '$ORIGIN/libyaml-cpp-pace.0.6.dylib' (no such file), '$ORIGIN/libyaml-cpp-pace.0.6.dylib' (no such file), '/Users/ikeda/miniconda3/envs/myenv/bin/../lib/libyaml-cpp-pace.0.6.dylib' (no such file), '/Users/ikeda/miniconda3/envs/myenv/bin/../lib/libyaml-cpp-pace.0.6.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS@rpath/libyaml-cpp-pace.0.6.dylib' (no such file), '$ORIGIN/libyaml-cpp-pace.0.6.dylib' (no such file), '$ORIGIN/libyaml-cpp-pace.0.6.dylib' (no such file), '/Users/ikeda/miniconda3/envs/myenv/bin/../lib/libyaml-cpp-pace.0.6.dylib' (no such file), '/Users/ikeda/miniconda3/envs/myenv/bin/../lib/libyaml-cpp-pace.0.6.dylib' (no such file), '/usr/local/lib/libyaml-cpp-pace.0.6.dylib' (no such file), '/usr/lib/libyaml-cpp-pace.0.6.dylib' (no such file, not in dyld cache)
```
In a Linux system, I did not get the error above.

After a bit of surveys and trials, I realized that giving `@loader_path` instead of `$ORIGIN` to `CMAKE_INSTALL_RPATH` in `setup.py` (or maybe equivalently in `CMakeLists.txt`) for MacOS solves the issue.

I am honestly not very familiar with cmake and pybind11 and cannot tell clearly why the above worked, but this may be not super unreasonable (https://stackoverflow.com/q/53428219).
