### PR TITLE
fix: missing include result to fail build

### DIFF
--- a/lib/ace/ace-evaluator/lib/yaml-cpp/src/emitterutils.cpp
+++ b/lib/ace/ace-evaluator/lib/yaml-cpp/src/emitterutils.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <iomanip>
+#include <cstdint> 
 #include <sstream>
 
 #include "emitterutils.h"


### PR DESCRIPTION
# Pull Request Template

Thank you for contributing to our project! Please review the checklist and fill out the details below.

## Description of Changes

<!-- Provide a brief description of the changes made in this pull request. -->

I got some build error message:

```
/home/newbee/prjs/ai/qm9_ml/python-ace-master/lib/ace/ace-evaluator/lib/yaml-cpp/src/emitterutils.cpp:221:11: error: ‘uint16_t’ was not declared in this scope

221 | std::pair<uint16_t, uint16_t> EncodeUTF16SurrogatePair(int codePoint) {

| ^~~~~~~~

/home/newbee/prjs/ai/qm9_ml/python-ace-master/lib/ace/ace-evaluator/lib/yaml-cpp/src/emitterutils.cpp:13:1: note: ‘uint16_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’

12 | #include "yaml-cpp/null.h"

+++ |+#include <cstdint>
```

So I just add the include for the type to the code in the file lib/ace/ace-evaluator/lib/yaml-cpp/src/emitterutils.cpp. Better solution would be updating yaml-cpp instead, but this is just a quick fix.

## Checklist

- [x] Code is well-documented.
- [x] All tests have been run and passed.
- [x] Relevant documentation has been updated if necessary.

## License Agreement

By submitting this pull request, I agree that:
- The code submitted in this pull request will be distributed under the Academic Software License (free for academic non-commercial use, not free for commercial use), see [LICENSE.md](https://github.com/ICAMS/python-ace/blob/master/LICENSE.md) for more details.
- The copyright for the code, including the submitted code, remains with Ruhr University Bochum.  Ruhr University Bochum retains the right to transfer or modify the copyright.

---

Thank you for your contribution!
