### PR TITLE
Make PyACECalculator deal with pickle

### DIFF
--- a/src/pyace/asecalc.py
+++ b/src/pyace/asecalc.py
@@ -213,9 +213,21 @@ PyACE ASE calculator
         self.current_extrapolation_structure_index += 1
 
     def __reduce__(self):
-        di = self.todict()
-        di.pop('basis_set', None)
-        return (type(self), (self.basis.to_BBasisConfiguration(),), self.todict())
+        # B-basis potentials are dumped as a full BBasisConfiguration, so that
+        # unpickling works on other machines or in different locations even if
+        # the calculator was created from a file name.  Ctilde basis sets
+        # cannot be converted back to a BBasisConfiguration, but their binding
+        # provides native pickle support, so they are passed through as is.
+        if isinstance(self.basis, ACEBBasisSet):
+            basis_spec = self.basis.to_BBasisConfiguration()
+        else:
+            basis_spec = self.basis
+        kwargs = {k: v for k, v in self.parameters.items() if k != "basis_set"}
+        return (_unpickle_calculator, (type(self), basis_spec, kwargs))
+
+
+def _unpickle_calculator(cls, basis_spec, kwargs):
+    return cls(basis_spec, **kwargs)
 
 class PyACEEnsembleCalculator(Calculator):
     """

--- a/src/pyace/asecalc.py
+++ b/src/pyace/asecalc.py
@@ -212,6 +212,10 @@ PyACE ASE calculator
         write(fname, atoms, format="cfg")
         self.current_extrapolation_structure_index += 1
 
+    def __reduce__(self):
+        di = self.todict()
+        di.pop('basis_set', None)
+        return (type(self), (self.basis.to_BBasisConfiguration(),), self.todict())
 
 class PyACEEnsembleCalculator(Calculator):
     """

--- a/tests/test_PyACECalculator.py
+++ b/tests/test_PyACECalculator.py
@@ -254,19 +254,33 @@ def test_ZBL_analytical_derivative():
     check(at, "ZBL forces are inconsistent")
 
 
-def check_pickle_roundtrip(calc):
-    a = create_dimer(2.0)
-    a.set_calculator(calc)
-    e1 = a.get_potential_energy()
-    f1 = a.get_forces()
+def minimize_dimer(calc, elements):
+    from ase.optimize import BFGS
 
+    at = Atoms(elements, positions=[[0, 0, 0], [0, 0, 2.0]], pbc=False)
+    at.set_calculator(calc)
+
+    energies = [at.get_potential_energy()]
+    forces = [at.get_forces()]
+
+    opt = BFGS(at, logfile=None)
+    opt.attach(lambda: (energies.append(at.get_potential_energy()),
+                        forces.append(at.get_forces())))
+    opt.run(fmax=1e-3, steps=50)
+
+    return np.array(energies), np.array(forces)
+
+
+def check_pickle_roundtrip(calc, elements=("Al", "Al")):
     calc2 = pickle.loads(pickle.dumps(calc))
 
-    b = create_dimer(2.0)
-    b.set_calculator(calc2)
-    e2 = b.get_potential_energy()
-    f2 = b.get_forces()
+    # minimize the dimer with the original and the unpickled calculator and
+    # compare energies/forces along the whole trajectory
+    e1, f1 = minimize_dimer(calc, elements)
+    e2, f2 = minimize_dimer(calc2, elements)
 
+    assert len(e1) > 1
+    assert e1.shape == e2.shape
     assert np.allclose(e1, e2)
     assert np.allclose(f1, f2)
     return calc2
@@ -282,6 +296,13 @@ def test_pickle_bbasis_calculator():
 def test_pickle_ctilde_calculator():
     calc = PyACECalculator(basis_set="tests/Al.pbe.rhocore.ace")
     calc2 = check_pickle_roundtrip(calc)
+    assert isinstance(calc2.basis, ACECTildeBasisSet)
+    assert isinstance(calc2.evaluator, ACECTildeEvaluator)
+
+
+def test_pickle_yace_calculator():
+    calc = PyACECalculator(basis_set="tests/Al-Ni_opt_all.yace")
+    calc2 = check_pickle_roundtrip(calc, elements=("Al", "Ni"))
     assert isinstance(calc2.basis, ACECTildeBasisSet)
     assert isinstance(calc2.evaluator, ACECTildeEvaluator)
 

--- a/tests/test_PyACECalculator.py
+++ b/tests/test_PyACECalculator.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pytest
 
@@ -250,3 +252,45 @@ def test_ZBL_analytical_derivative():
 
     at = Atoms("H2", positions=[[0, 0, 0], [0, 0, 1.5]])  # ZBL
     check(at, "ZBL forces are inconsistent")
+
+
+def check_pickle_roundtrip(calc):
+    a = create_dimer(2.0)
+    a.set_calculator(calc)
+    e1 = a.get_potential_energy()
+    f1 = a.get_forces()
+
+    calc2 = pickle.loads(pickle.dumps(calc))
+
+    b = create_dimer(2.0)
+    b.set_calculator(calc2)
+    e2 = b.get_potential_energy()
+    f2 = b.get_forces()
+
+    assert np.allclose(e1, e2)
+    assert np.allclose(f1, f2)
+    return calc2
+
+
+def test_pickle_bbasis_calculator():
+    calc = PyACECalculator(basis_set="tests/Al.pbe.13.2.yaml")
+    calc2 = check_pickle_roundtrip(calc)
+    assert isinstance(calc2.basis, ACEBBasisSet)
+    assert isinstance(calc2.evaluator, ACEBEvaluator)
+
+
+def test_pickle_ctilde_calculator():
+    calc = PyACECalculator(basis_set="tests/Al.pbe.rhocore.ace")
+    calc2 = check_pickle_roundtrip(calc)
+    assert isinstance(calc2.basis, ACECTildeBasisSet)
+    assert isinstance(calc2.evaluator, ACECTildeEvaluator)
+
+
+def test_pickle_ctilde_recursive_calculator():
+    from pyace.evaluator import ACERecursiveEvaluator
+
+    calc = PyACECalculator(basis_set="tests/Al.pbe.rhocore.ace",
+                           recursive_evaluator=True, recursive=True)
+    calc2 = check_pickle_roundtrip(calc)
+    assert isinstance(calc2.basis, ACECTildeBasisSet)
+    assert isinstance(calc2.evaluator, ACERecursiveEvaluator)


### PR DESCRIPTION


# Pull Request Template

Thank you for contributing to our project! Please review the checklist and fill out the details below.

## Description of Changes

The default reducer puts out the evaluator and a bunch of other C++ extension types that pickle then chokes on. Side step the problem here by providing a reducer that just makes unpickling equivalent to a new instantiation. The only difficulty here is that basis_set stays a file name if initialized like that and that PyACECalculator.__init__ expects it as a positional argument.
Avoid the filename by dumping the whole bbasis config, so that unpickling can happen on other machines or in different locations.

## Checklist

- [x] Code is well-documented.
- [ ] All tests have been run and passed.
- [ ] Relevant documentation has been updated if necessary.

## License Agreement

By submitting this pull request, I agree that:
- The code submitted in this pull request will be distributed under the Academic Software License (free for academic non-commercial use, not free for commercial use), see [LICENSE.md](https://github.com/ICAMS/python-ace/blob/master/LICENSE.md) for more details.
- The copyright for the code, including the submitted code, remains with Ruhr University Bochum.  Ruhr University Bochum retains the right to transfer or modify the copyright.

---

Thank you for your contribution!
