### PR TITLE
Support up to pandas 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,17 @@ jobs:
         #python setup.py install
         pip install . 
     - name: Install python-ace
-      run: |    
+      run: |
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         #python setup.py install
-        pip install . 
+        pip install .
+    - name: Install maxvolpy
+      run: |
+        # pip install . does not run the setup.py install hook that installs
+        # the vendored maxvolpy, so install it explicitly. Its setup.py imports
+        # Cython and numpy at the top level, hence no build isolation.
+        pip install cython
+        pip install --no-build-isolation ./lib/maxvolpy
     - name: Test with python-ace with tensorpotential
       run: |
         python -m pytest tests/ --runtensorpot

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ setup(
     url='https://github.com/ICAMS/python-ace',
     install_requires=['numpy<=1.26.4',
                       'ase',
-                      'pandas<=2.0',
+                      'pandas<=3.0',
                       'ruamel.yaml',
                       'psutil',
                       'scikit-learn<=1.4.2'

--- a/setup.py
+++ b/setup.py
@@ -194,7 +194,7 @@ setup(
     url='https://github.com/ICAMS/python-ace',
     install_requires=['numpy<=1.26.4',
                       'ase',
-                      'pandas<=3.0',
+                      'pandas>=2,<4',
                       'ruamel.yaml',
                       'psutil',
                       'scikit-learn<=1.4.2'

--- a/tests/test_PyACECalculator.py
+++ b/tests/test_PyACECalculator.py
@@ -188,7 +188,11 @@ def test_fcc_stress():
 
 
 def test_relaxation():
-    from ase.constraints import UnitCellFilter
+    try:
+        from ase.filters import UnitCellFilter
+    except ImportError:
+        # ase < 3.23
+        from ase.constraints import UnitCellFilter
     from ase.optimize import QuasiNewton
 
     calc = PyACECalculator(basis_set="tests/Al.pbe.rhocore-v2.ace")


### PR DESCRIPTION
# Pull Request Template

Thank you for contributing to our project! Please review the checklist and fill out the details below.

## Description of Changes

Widens the pandas requirement in setup.py from pandas<=2.0 to pandas>=2,<4, covering the whole pandas 2.x and 3.x series.

The codebase was audited for pandas 3 blockers; none were found:

    No use of APIs removed in pandas 2/3 (DataFrame.append, applymap, Series.iteritems, delim_whitespace, .ix).
    No chained assignment — all DataFrame writes go through df[col] = ... or df.loc[mask, col] = ..., so pandas 3's enforced Copy-on-Write does not change behavior.
    All .map() calls operate on Series/Index objects, so nothing depends on DataFrame.map (introduced in 2.1), keeping the 2.0 lower bound valid.
    Legacy pickled reference DataFrames (tests/*.pckl.gzip, [data/exmpl_df.pckl.gzip](https://github.com/pmrv/python-ace/blob/claude/sleepy-dijkstra-luopd2/data/exmpl_df.pckl.gzip)) load correctly under pandas 3, with object dtype preserved.
    The existing numpy<=1.26.4 pin satisfies pandas 3's numpy ≥1.26 requirement.

Also installs the vendored lib/maxvolpy explicitly in the test workflow: pip install . does not run the custom setup.py install hook, so test_activelearning/test_activeexploration failed collection in CI with ModuleNotFoundError: maxvolpy.

## Checklist

- [x] Code is well-documented.
- [x] All tests have been run and passed.
- [x] Relevant documentation has been updated if necessary.

## License Agreement

By submitting this pull request, I agree that:
- The code submitted in this pull request will be distributed under the Academic Software License (free for academic non-commercial use, not free for commercial use), see [LICENSE.md](https://github.com/ICAMS/python-ace/blob/master/LICENSE.md) for more details.
- The copyright for the code, including the submitted code, remains with Ruhr University Bochum.  Ruhr University Bochum retains the right to transfer or modify the copyright.

---

Thank you for your contribution!
