### PR TITLE
Drop runtime pkg_resources dependency for setuptools >= 82 compatibility

### DIFF
--- a/bin/pacemaker
+++ b/bin/pacemaker
@@ -5,8 +5,15 @@ import getpass  # for getpass.getuser()
 import glob
 import logging
 import os
-import pkg_resources
 import re
+
+try:
+    from importlib.resources import files as _importlib_files
+
+    def _resource_filename(package, resource):
+        return str(_importlib_files(package) / resource)
+except ImportError:  # Python 3.8: importlib.resources.files is not available
+    from pkg_resources import resource_filename as _resource_filename
 
 try:
     import readline
@@ -343,7 +350,7 @@ def generate_template_input():
         weighting = None
         print("Use UniformWeightingPolicy")
 
-    template_input_yaml_filename = pkg_resources.resource_filename('pyace.data', 'input_template.yaml')
+    template_input_yaml_filename = _resource_filename('pyace.data', 'input_template.yaml')
     copyfile(template_input_yaml_filename, "input.yaml")
     with open("input.yaml", "r") as f:
         input_yaml_text = f.read()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 import platform
-from distutils.version import LooseVersion
 from setuptools import Extension, setup, find_packages
 from setuptools.command.build_ext import build_ext
 from setuptools.command.install import install

--- a/src/pyace/multispecies_basisextension.py
+++ b/src/pyace/multispecies_basisextension.py
@@ -1,8 +1,15 @@
 import logging
 import numpy as np
 import pickle
-import pkg_resources
 import re
+
+try:
+    from importlib.resources import files as _importlib_files
+
+    def _resource_filename(package, resource):
+        return str(_importlib_files(package) / resource)
+except ImportError:  # Python 3.8: importlib.resources.files is not available
+    from pkg_resources import resource_filename as _resource_filename
 
 from collections import defaultdict
 from copy import deepcopy
@@ -44,8 +51,8 @@ PERIODIC_ELEMENTS = chemical_symbols = [
     'Rf', 'Db', 'Sg', 'Bh', 'Hs', 'Mt', 'Ds', 'Rg', 'Cn', 'Nh', 'Fl', 'Mc',
     'Lv', 'Ts', 'Og']
 
-default_mus_ns_uni_to_rawlsLS_np_rank_filename = pkg_resources.resource_filename('pyace.data',
-                                                                                 'mus_ns_uni_to_rawlsLS_np_rank.pckl')
+default_mus_ns_uni_to_rawlsLS_np_rank_filename = _resource_filename('pyace.data',
+                                                                    'mus_ns_uni_to_rawlsLS_np_rank.pckl')
 
 def clean_bbasisconfig(initial_bbasisconfig):
     for block in initial_bbasisconfig.funcspecs_blocks:


### PR DESCRIPTION
setuptools 82 removed the pkg_resources module entirely, which broke 'pacemaker' and pyace.multispecies_basisextension at import time (ModuleNotFoundError: No module named 'pkg_resources').

Replace pkg_resources.resource_filename with importlib.resources.files, keeping a pkg_resources fallback for Python 3.8 where importlib.resources.files is unavailable. Also drop the unused distutils.version.LooseVersion import from setup.py (distutils was removed from the stdlib in Python 3.12).

## Description of Changes

<!-- Provide a brief description of the changes made in this pull request. -->

## Checklist

- [x] Code is well-documented.
- [x] All tests have been run and passed.
- [x] Relevant documentation has been updated if necessary.

## License Agreement

By submitting this pull request, I agree that:
- The code submitted in this pull request will be distributed under the Academic Software License (free for academic non-commercial use, not free for commercial use), see [LICENSE.md](https://github.com/ICAMS/python-ace/blob/master/LICENSE.md) for more details.
- The copyright for the code, including the submitted code, remains with Ruhr University Bochum.  Ruhr University Bochum retains the right to transfer or modify the copyright.

---

Thank you for your contribution!
