### PR TITLE
Widen scikit-learn constraint to <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -197,7 +197,7 @@ setup(
                       'pandas<=2.0',
                       'ruamel.yaml',
                       'psutil',
-                      'scikit-learn<=1.4.2'
+                      'scikit-learn<2'
                       ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
## Description of Changes

The <=1.4.2 pin came from a blanket version-pinning commit; the only sklearn usage is Ridge from sklearn.linear_model, which is stable across 1.x releases. Match the style of the numpy/pandas constraints.

## Checklist

- [x] Code is well-documented.
- [x] All tests have been run and passed.
- [x] Relevant documentation has been updated if necessary.

## License Agreement

By submitting this pull request, I agree that:
- The code submitted in this pull request will be distributed under the Academic Software License (free for academic non-commercial use, not free for commercial use), see [LICENSE.md](https://github.com/ICAMS/python-ace/blob/master/LICENSE.md) for more details.
- The copyright for the code, including the submitted code, remains with Ruhr University Bochum.  Ruhr University Bochum retains the right to transfer or modify the copyright.

---

Thank you for your contribution!
